### PR TITLE
Fix warnings

### DIFF
--- a/src/test/scala/ExplicitNullsSpec.scala
+++ b/src/test/scala/ExplicitNullsSpec.scala
@@ -54,7 +54,7 @@ final class ExplicitNullsSpec extends BaseSpec {
 
   "Match Case" in {
 
-    val s: String | Null = "abc"
+    val s: Matchable & (String | Null) = "abc"
     val t = s match
       case _: String => "not null"
       case _         => "null"


### PR DESCRIPTION
```
[warn] 59 |      case _: String => "not null"
[warn]    |           ^^^^^^^^^
[warn]    |           pattern selector should be an instance of Matchable,,
[warn]    |           but it has unmatchable type Matchable & String | Null instead
```