### PR TITLE
Update coursier/cache-action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 11
 
       - name: Cache Coursier
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6
 
       - name: Run All Check
         run: |


### PR DESCRIPTION
* https://github.com/coursier/cache-action/releases/tag/v6
* https://github.com/coursier/cache-action/releases/tag/v6.1
* https://github.com/coursier/cache-action/releases/tag/v6.2
* https://github.com/coursier/cache-action/releases/tag/v6.3